### PR TITLE
fix: add scrollbar for overflowing text

### DIFF
--- a/app/views/fields/code/_show.html.erb
+++ b/app/views/fields/code/_show.html.erb
@@ -20,6 +20,7 @@ By default, the attribute is rendered as a code block with the data
   font-size: 12px;
   background: rgba(0, 0, 0, .1);
   padding: 10px;
-  margin: -10px;
+  margin: 0px;
   border: 1px solid rgba(0, 0, 0, .3);
+  overflow-x: auto;
 "><code><%= field.to_s %></code></pre>


### PR DESCRIPTION
Hey @SleeplessByte, thank you for this nice Administrate plugin :) 

I was using this gem into my project, and I noticed an issue when the text is very long inside of the `<code>` element. Here's  a screenshot with your current CSS styling
<img width="995" alt="Screenshot 2023-09-05 at 14 54 21" src="https://github.com/XPBytes/administrate-field-code/assets/97030518/eb42b31c-33af-4e6d-a552-cdbb336d5f20">

Here's a screenshot from Chrome with the current changes I propose you :) 
<img width="947" alt="Screenshot 2023-09-05 at 15 42 42" src="https://github.com/XPBytes/administrate-field-code/assets/97030518/4768b013-d2b8-48fe-a4b4-3b27a998c689">

As you see, now the margin is consistent with the other administrate fields (they all have 0 margin) and a scrollbar has been added. The scrollbar is added **only** if there is overflowing text tho :) 

Let me know what you think :D